### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/michelpureza0175/51ab1fbc-4953-4321-8645-fbb6cceaad1e/2271b670-9fef-45de-9608-452c4ac97947/_apis/work/boardbadge/e723f4d1-3280-4f75-903a-bb8bfbbcc282)](https://dev.azure.com/michelpureza0175/51ab1fbc-4953-4321-8645-fbb6cceaad1e/_boards/board/t/2271b670-9fef-45de-9608-452c4ac97947/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/michelpureza0175/51ab1fbc-4953-4321-8645-fbb6cceaad1e/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.